### PR TITLE
Made actions parser more tolerant

### DIFF
--- a/.github/actions/env-req-parser/env-req-parser.js
+++ b/.github/actions/env-req-parser/env-req-parser.js
@@ -43,17 +43,21 @@ const run = async () => {
         for (var i = 0; i < lines.length; i++) {
             if (lines[i].startsWith("Application Name:"))
                 appName = lines[i].substring(17, lines[i].length).trim();
-            if (lines[i].startsWith("- [x] General"))
+            
+            lines[i] = lines[i].toLowerCase()   // convert line to lowercase
+            lines[i] = lines[i].replace(/\s/g, "");  // remove spaces from line
+            
+            if (lines[i].startsWith("-[x]general"))
                 armTemplate = "vmss-windows-nat";
-            if (lines[i].startsWith("- [x] Web"))
+            if (lines[i].startsWith("-[x]web"))
                 armTemplate = "web-app-sql-database";
-            if (lines[i].startsWith("- [x] Serverless"))
+            if (lines[i].startsWith("-[x]serverless"))
                 armTemplate = "function-app";
-            if (lines[i].startsWith("- [x] PCI")) {
+            if (lines[i].startsWith("-[x]pci")) {
                 applyPolicy = true;
                 policyName = "Audit PCI";
             }
-            if (lines[i].startsWith("- [x] HIPAA")) {
+            if (lines[i].startsWith("-[x]hipaa")) {
                 applyPolicy = true;
                 policyName = "Audit HITRUST/HIPAA";
             }

--- a/.github/actions/env-req-parser/env-req-parser.ts
+++ b/.github/actions/env-req-parser/env-req-parser.ts
@@ -28,19 +28,21 @@ const run = async (): Promise<void> => {
         if (!lines) return
 
         for (var i=0;i<lines.length;i++) {
+            lines[i] = lines[i].toLowerCase()   // convert line to lowercase
+            lines[i] = lines[i].replace(/\s/g, "");  // remove spaces from line
             if (lines[i].startsWith("Application Name:"))
                 appName = lines[i].substring(17,lines[i].length).trim()
-            if (lines[i].startsWith("- [x] General"))
+            if (lines[i].startsWith("-[x]general"))
                 armTemplate = "vmss-windows-nat"
-            if (lines[i].startsWith("- [x] Web"))
+            if (lines[i].startsWith("-[x]web"))
                 armTemplate = "web-app-sql-database"
-            if (lines[i].startsWith("- [x] Serverless"))
+            if (lines[i].startsWith("-[x]serverless"))
                 armTemplate = "function-app"
-            if (lines[i].startsWith("- [x] PCI")) {
+            if (lines[i].startsWith("-[x]pci")) {
                 applyPolicy = true
                 policyName = "Audit PCI"
             }
-            if (lines[i].startsWith("- [x] HIPAA")) {
+            if (lines[i].startsWith("-[x]hipaa")) {
                 applyPolicy = true
                 policyName = "Audit HITRUST/HIPAA"
             }

--- a/.github/actions/env-req-parser/env-req-parser.ts
+++ b/.github/actions/env-req-parser/env-req-parser.ts
@@ -28,10 +28,12 @@ const run = async (): Promise<void> => {
         if (!lines) return
 
         for (var i=0;i<lines.length;i++) {
-            lines[i] = lines[i].toLowerCase()   // convert line to lowercase
-            lines[i] = lines[i].replace(/\s/g, "");  // remove spaces from line
             if (lines[i].startsWith("Application Name:"))
                 appName = lines[i].substring(17,lines[i].length).trim()
+            
+            lines[i] = lines[i].toLowerCase()   // convert line to lowercase
+            lines[i] = lines[i].replace(/\s/g, "");  // remove spaces from line
+            
             if (lines[i].startsWith("-[x]general"))
                 armTemplate = "vmss-windows-nat"
             if (lines[i].startsWith("-[x]web"))


### PR DESCRIPTION
I cleaned up Nick's parsing code to be more tolerant of input.  Prior to this cleanup, when a user checked a box in the form, it had to be exactly "[x]".  If an extra space was entered (eg, "[x ]"), or if the 'x' was entered as uppercase ("X"), the parsing would fail.

I modified the code so that neither the case nor extra spaces matter.
